### PR TITLE
For I, S and Z the move generator finds moves twice

### DIFF
--- a/src/Tetris/Block.cs
+++ b/src/Tetris/Block.cs
@@ -19,7 +19,7 @@ namespace Tetris
         /// <summary>Gets the identifier of the block.</summary>
         public short Id { get; internal set; }
 
-        /// <summary>Gets the hash of the block.</summary>
+        /// <summary>Gets the primary (identifier) of the block.</summary>
         public short Primary { get; internal set; }
 
         /// <summary>Gets <see cref="Tetris.Shape"/> of the block.</summary>

--- a/src/Tetris/Block.cs
+++ b/src/Tetris/Block.cs
@@ -15,8 +15,12 @@ namespace Tetris
             Column = column;
             Offset = offset;
         }
+        
         /// <summary>Gets the identifier of the block.</summary>
-        public short Hash { get; internal set; }
+        public short Id { get; internal set; }
+
+        /// <summary>Gets the hash of the block.</summary>
+        public short Primary { get; internal set; }
 
         /// <summary>Gets <see cref="Tetris.Shape"/> of the block.</summary>
         public Shape Shape { get; }

--- a/src/Tetris/Blocks.Init.cs
+++ b/src/Tetris/Blocks.Init.cs
@@ -28,12 +28,25 @@ namespace Tetris
 
             foreach (var shape in Shapes.All)
             {
-                short hash = 0;
+                short id = 0;
                 foreach (var block in blocks.Where(b => b.Shape == shape))
                 {
-                    block.Hash = hash++;
+                    block.Id = id++;
                     blocks.Count++;
                 }
+            }
+            foreach(var block in blocks)
+            {
+                var primary = block.Shape.HasPrimary()
+                    ? blocks
+                        .Select(
+                            col: block.Column,
+                            offset: block.Offset,
+                            shape: block.Shape,
+                            rotation: block.Rotation.Primary()) ?? block
+                    : block;
+
+                block.Primary = primary.Id;
             }
 
             return blocks;

--- a/src/Tetris/Blocks.cs
+++ b/src/Tetris/Blocks.cs
@@ -23,7 +23,7 @@ namespace Tetris
            => Select(col, offset, shape, rotation, 0);
 
         public Block Select(int col, int offset, Shape shape, Rotation rotation, int add)
-            => items[col][offset][(int)shape][rotation.Rotate(add)];
+            => items[col][offset][(int)shape][rotation.Rotate(add).Int()];
 
         public IEnumerator<Block> GetEnumerator() => items
             .SelectMany(m => m)

--- a/src/Tetris/Generation/MoveCandidate.cs
+++ b/src/Tetris/Generation/MoveCandidate.cs
@@ -27,7 +27,9 @@ namespace Tetris.Generation
             => new MoveCandidate(candidate.Block, Steps.Add(candidate.Steps.First));
 
         internal int Offset => Block.Offset;
-        internal short Hash => Block.Hash;
+        internal short Id => Block.Id; 
+        internal short Primary => Block.Primary;
+
         internal IEnumerable<MoveCandidate> Nexts => Block.Nexts;
         internal IEnumerable<MoveCandidate> Others => Block.Others;
     }

--- a/src/Tetris/Generation/MoveGenerator.cs
+++ b/src/Tetris/Generation/MoveGenerator.cs
@@ -9,8 +9,7 @@ namespace Tetris.Generation
     public class MoveGenerator : IEnumerator<MoveCandidate>, IEnumerable<MoveCandidate>
     {
         private Field field;
-        private readonly Visited visted = new Visited();
-        private readonly Visited moved = new Visited();
+        private readonly Tracker tracker = new Tracker();
         private readonly FixedQueue<MoveCandidate> queue = new FixedQueue<MoveCandidate>(4000 / 7);
 
         public MoveGenerator(Field field, Block block)
@@ -60,7 +59,7 @@ namespace Tetris.Generation
         {
             foreach (var next in nexts)
             {
-                if (visted.Add(next.Id))
+                if (tracker.Visit(next.Id))
                 {
                     queue.Enqueue(candidate.Next(next));
                 }
@@ -71,7 +70,7 @@ namespace Tetris.Generation
         private bool NewMove(MoveCandidate candidate)
         {
             Current = candidate;
-            return moved.Add(candidate.Primary);
+            return tracker.Move(candidate.Primary);
         }
 
         public void Reset() => field = default;

--- a/src/Tetris/Generation/MoveGenerator.cs
+++ b/src/Tetris/Generation/MoveGenerator.cs
@@ -10,6 +10,7 @@ namespace Tetris.Generation
     {
         private Field field;
         private readonly Visited visted = new Visited();
+        private readonly Visited moved = new Visited();
         private readonly FixedQueue<MoveCandidate> queue = new FixedQueue<MoveCandidate>(4000 / 7);
 
         public MoveGenerator(Field field, Block block)
@@ -45,7 +46,7 @@ namespace Tetris.Generation
             else if (fit == Fit.True)
             {
                 Enqueue(candidate, candidate.Others);
-                return Set(candidate);
+                return NewMove(candidate) || MoveNext();
             }
             else /* if (fit == Fit.Maybe) */
             {
@@ -59,7 +60,7 @@ namespace Tetris.Generation
         {
             foreach (var next in nexts)
             {
-                if (visted.Add(next.Hash))
+                if (visted.Add(next.Id))
                 {
                     queue.Enqueue(candidate.Next(next));
                 }
@@ -67,12 +68,10 @@ namespace Tetris.Generation
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool Set(MoveCandidate candidate)
+        private bool NewMove(MoveCandidate candidate)
         {
-            // TODO: for blocks that have a rotated
-            // version, check if that one has been passed.
             Current = candidate;
-            return true;
+            return moved.Add(candidate.Primary);
         }
 
         public void Reset() => field = default;

--- a/src/Tetris/Generation/Tracker.cs
+++ b/src/Tetris/Generation/Tracker.cs
@@ -9,35 +9,50 @@ namespace Tetris.Generation
 {
     [DebuggerDisplay("{DebuggerDisplay}")]
     [DebuggerTypeProxy(typeof(CollectionDebugView))]
-    public sealed class Visited : IEnumerable<int>
+    public sealed class Tracker : IEnumerable<int>
     {
-        private const byte True = 255;
+        private const byte Visited = 1;
+        private const byte Moved = 255;
         private const int capacity = 600;
 
         private readonly byte[] lookup = new byte[capacity];
 
         public int Count => this.Count();
 
-        public bool Add(int hash)
+        public bool Visit(int id)
         {
-            var visited = lookup[hash];
-            if(visited == True)
+            var value = lookup[id];
+            if(value != default)
             {
                 return false;
             }
             else
             {
-                lookup[hash] = True;
+                lookup[id] = Visited;
                 return true;
             }
         }
 
+        public bool Move(int id)
+        {
+            var value = lookup[id];
+            if (value == Moved)
+            {
+                return false;
+            }
+            else
+            {
+                lookup[id] = Moved;
+                return true;
+            }
+        }
+        
         public void Clear() => Array.Clear(lookup, 0, capacity);
 
         public IEnumerator<int> GetEnumerator()
             => lookup
             .Select((hash, i) => i)
-            .Where(i => lookup[i] == True)
+            .Where(i => lookup[i] != default)
             .GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();

--- a/src/Tetris/Rotation.cs
+++ b/src/Tetris/Rotation.cs
@@ -1,23 +1,32 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
 
 namespace Tetris
 {
-    public readonly struct Rotation
+    public enum Rotation : byte
     {
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly byte val;
-
-        public static readonly Rotation None;
-        public static readonly Rotation Right = new Rotation(1);
-        public static readonly Rotation Uturn = new Rotation(2);
-        public static readonly Rotation Left = new Rotation(3);
-
-        public Rotation(int val) => this.val = (byte)(val & 3);
-
-        public Rotation Rotate(int steps) => new Rotation(val + steps);
-
-        public override string ToString() => new[] { "None", "Right", "U-turn", "Left" }[val];
-
-        public static implicit operator int(Rotation r) => r.val;
+        None = 0,
+        Right = 1,
+        Uturn = 2,
+        Left = 3,
     }
+
+    public static class Rotations
+    {
+        public static readonly IReadOnlyList<Rotation> All = new[]
+        {
+            Rotation.None,
+            Rotation.Right,
+            Rotation.Uturn,
+            Rotation.Left,
+        };
+
+        public static int Int(this Rotation rotation) => (int)rotation;
+
+        public static Rotation Primary(this Rotation rotation)
+            => (Rotation)(rotation.Int() & 1);
+
+        public static Rotation Rotate(this Rotation rotation, int steps)
+            => (Rotation)((rotation.Int() + steps) & 3);
+    }
+
 }

--- a/src/Tetris/RotationSystems/SuperRotationSystem.cs
+++ b/src/Tetris/RotationSystems/SuperRotationSystem.cs
@@ -33,7 +33,7 @@
 
         private static Offset Offset(Shape shape, Rotation rotation, int add) => offsets
            [(int)shape]
-           [rotation.Rotate(add)];
+           [rotation.Rotate(add).Int()];
 
         private static readonly Offset[][] offsets = new Offset[][]
         {

--- a/src/Tetris/Rows.cs
+++ b/src/Tetris/Rows.cs
@@ -32,10 +32,10 @@ namespace Tetris
             : new Block(this, shape, rotation, column, offset);
 
         public int Columns(Shape shape, Rotation rotation)
-            => rows[(int)shape][rotation].Length;
+            => rows[(int)shape][rotation.Int()].Length;
 
         public Row[] Select(Shape shape, Rotation rotation, int column)
-            => rows[(int)shape][rotation][column];
+            => rows[(int)shape][rotation.Int()][column];
 
         public static Rows All()
         {

--- a/src/Tetris/Shapes.cs
+++ b/src/Tetris/Shapes.cs
@@ -124,5 +124,10 @@
             0b01000_00000,
             0b11000_00000,
             0b10000_00000);
+
+        public static bool HasPrimary(this Shape shape)
+            => shape == Shape.I
+            || shape == Shape.S
+            || shape == Shape.Z;
     }
 }

--- a/test/Testris.Specs/Block_specs.cs
+++ b/test/Testris.Specs/Block_specs.cs
@@ -9,6 +9,23 @@ namespace Block_specs
     public class Initialized
     {
         [Test]
+        public void For_JLOT_IDs_and_Primaries_are_equal()
+        {
+            var blocks = Blocks.Init();
+
+            var JLOT = blocks.Where(b
+                => b.Shape == Shape.J
+                || b.Shape == Shape.L
+                || b.Shape == Shape.O
+                || b.Shape == Shape.T);
+
+            foreach(var block in JLOT)
+            {
+                Assert.AreEqual(block.Id, block.Primary, block.ToString());
+            }
+        }
+
+        [Test]
         public void Within_10ms()
         {
             var rows = Rows.All();

--- a/test/Testris.Specs/Block_specs.cs
+++ b/test/Testris.Specs/Block_specs.cs
@@ -26,10 +26,10 @@ namespace Block_specs
         }
 
         [Test]
-        public void Within_10ms()
+        public void Within_50ms()
         {
             var rows = Rows.All();
-            Speed.Runs(() => Blocks.Init(rows, null), 1, TimeSpan.FromMilliseconds(10));
+            Speed.Runs(() => Blocks.Init(rows, null), 1, TimeSpan.FromMilliseconds(50));
         }
 
         [Test]

--- a/test/Testris.Specs/Rotation_specs.cs
+++ b/test/Testris.Specs/Rotation_specs.cs
@@ -1,0 +1,38 @@
+﻿using NUnit.Framework;
+using Tetris;
+
+namespace Rotation_specs
+{
+    public class Primary
+    {
+        [TestCase(Rotation.None, Rotation.None)]
+        [TestCase(Rotation.Right, Rotation.Right)]
+        [TestCase(Rotation.None, Rotation.Uturn)]
+        [TestCase(Rotation.Right, Rotation.Left)]
+        public void Is(Rotation primary, Rotation rotation)
+        {
+            Assert.AreEqual(primary, rotation.Primary());
+        }
+    }
+
+    public class Rotate
+    {
+        [TestCase(Rotation.Left, Rotation.None)]
+        [TestCase(Rotation.None, Rotation.Right)]
+        [TestCase(Rotation.Right, Rotation.Uturn)]
+        [TestCase(Rotation.Uturn, Rotation.Left)]
+        public void Clockwise(Rotation rotated, Rotation rotation)
+        {
+            Assert.AreEqual(rotated, rotation.Rotate(-1));
+        }
+
+        [TestCase(Rotation.Right, Rotation.None)]
+        [TestCase(Rotation.Uturn, Rotation.Right)]
+        [TestCase(Rotation.Left, Rotation.Uturn)]
+        [TestCase(Rotation.None, Rotation.Left)]
+        public void CounterClockwise(Rotation rotated, Rotation rotation)
+        {
+            Assert.AreEqual(rotated, rotation.Rotate(+1));
+        }
+    }
+}

--- a/test/Testris.Specs/Row_specs.cs
+++ b/test/Testris.Specs/Row_specs.cs
@@ -8,39 +8,34 @@ namespace Row_specs
 {
     public class All
     {
-        private const int None = 0;
-        private const int Right = 1;
-        private const int UTurn = 2;
-        private const int Left = 3;
-
-        [TestCase(07, Shape.I, None)]
-        [TestCase(10, Shape.I, Right)]
-        [TestCase(07, Shape.I, UTurn)]
-        [TestCase(10, Shape.I, Left)]
-        [TestCase(08, Shape.J, None)]
-        [TestCase(09, Shape.J, Right)]
-        [TestCase(08, Shape.J, UTurn)]
-        [TestCase(09, Shape.J, Left)]
-        [TestCase(08, Shape.L, None)]
-        [TestCase(09, Shape.L, Right)]
-        [TestCase(08, Shape.L, UTurn)]
-        [TestCase(09, Shape.L, Left)]
-        [TestCase(09, Shape.O, None)]
-        [TestCase(08, Shape.S, None)]
-        [TestCase(09, Shape.S, Right)]
-        [TestCase(08, Shape.S, UTurn)]
-        [TestCase(09, Shape.S, Left)]
-        [TestCase(08, Shape.T, None)]
-        [TestCase(09, Shape.T, Right)]
-        [TestCase(08, Shape.T, UTurn)]
-        [TestCase(09, Shape.T, Left)]
-        [TestCase(08, Shape.Z, None)]
-        [TestCase(09, Shape.Z, Right)]
-        [TestCase(08, Shape.Z, UTurn)]
-        [TestCase(09, Shape.Z, Left)]
-        public void Columns_have_values_between_7_and_10(int columns, Shape shape, int rotation)
+        [TestCase(07, Shape.I, Rotation.None)]
+        [TestCase(10, Shape.I, Rotation.Right)]
+        [TestCase(07, Shape.I, Rotation.Uturn)]
+        [TestCase(10, Shape.I, Rotation.Left)]
+        [TestCase(08, Shape.J, Rotation.None)]
+        [TestCase(09, Shape.J, Rotation.Right)]
+        [TestCase(08, Shape.J, Rotation.Uturn)]
+        [TestCase(09, Shape.J, Rotation.Left)]
+        [TestCase(08, Shape.L, Rotation.None)]
+        [TestCase(09, Shape.L, Rotation.Right)]
+        [TestCase(08, Shape.L, Rotation.Uturn)]
+        [TestCase(09, Shape.L, Rotation.Left)]
+        [TestCase(09, Shape.O, Rotation.None)]
+        [TestCase(08, Shape.S, Rotation.None)]
+        [TestCase(09, Shape.S, Rotation.Right)]
+        [TestCase(08, Shape.S, Rotation.Uturn)]
+        [TestCase(09, Shape.S, Rotation.Left)]
+        [TestCase(08, Shape.T, Rotation.None)]
+        [TestCase(09, Shape.T, Rotation.Right)]
+        [TestCase(08, Shape.T, Rotation.Uturn)]
+        [TestCase(09, Shape.T, Rotation.Left)]
+        [TestCase(08, Shape.Z, Rotation.None)]
+        [TestCase(09, Shape.Z, Rotation.Right)]
+        [TestCase(08, Shape.Z, Rotation.Uturn)]
+        [TestCase(09, Shape.Z, Rotation.Left)]
+        public void Columns_have_values_between_7_and_10(int columns, Shape shape, Rotation rotation)
         {
-            Assert.AreEqual(columns, Rows.All().Columns(shape, new Rotation(rotation)));
+            Assert.AreEqual(columns, Rows.All().Columns(shape, rotation));
         }
 
         [Test]


### PR DESCRIPTION
Because I, S and Z have basically only 2 rotations (their other 2 rotations are only relevant for the path) the generator should keep track of the blocks already committed to keep track of those.